### PR TITLE
fileupload type in Request body interface

### DIFF
--- a/src/api/api.controller.ts
+++ b/src/api/api.controller.ts
@@ -159,7 +159,7 @@ export class ApiController {
   @ApiOperation({summary: 'Get contributors of an API'})
   async getApiContributors(
     @Param('apiId')apiId: string
-  ): Promise<Ok<Profile[]>> {
+  ): Promise<Ok<any[]>> {
     const contributors = await this.apiService.getAllApiContributors(apiId);
     return ZaLaResponse.Ok(contributors, 'OK', '200');
   }

--- a/src/common/interfaces/endpoint.interface.ts
+++ b/src/common/interfaces/endpoint.interface.ts
@@ -2,7 +2,7 @@ import { EndpointHeaderType } from '../enums/endpointHeaderType.enum';
 
 export interface ReqBody {
   key: string;
-  value: string | Date | boolean | number | object | symbol | Array<any>;
+  value: string | Date | boolean | number | object | symbol | Array<any> | Express.Multer.File;
 }
 
 export interface DataType {

--- a/src/invitation/invitation.controller.ts
+++ b/src/invitation/invitation.controller.ts
@@ -45,7 +45,7 @@ export class InvitationController {
   @ApiOperation({ summary: 'Send Email Invite' })
   async getAllInvite(
     @Param('apiId') apiId: string,
-    ): Promise<Ok<Invitation[]>> {
+    ): Promise<Ok<any[]>> {
     const invites = await this.invitationService.getallInvitations( apiId);
     return ZaLaResponse.Ok(invites, 'Invites retrieved successfully', 200)
   }

--- a/src/invitation/invitation.service.ts
+++ b/src/invitation/invitation.service.ts
@@ -168,9 +168,14 @@ export class InvitationService {
 
   async getallInvitations( apiId: string) {
     try {
+      let pendingInvites = []
       const allInvites = await this.invitationRepo.find({where:{apiId: apiId}})
-     
-      return allInvites
+      if(allInvites.length < 1){
+        return allInvites
+      } else{
+        return pendingInvites
+      }
+
     } catch (error) {
         throw new BadRequestException(
           ZaLaResponse.BadRequest(


### PR DESCRIPTION
1. Included file type as part of the data values in the request body interface
2. changed promise return on api contributors to "any[ ]" so as not to return error when no contributors are present
3. changed promise return of invited users endpoint to "any[ ]" so as not to return error when no invitees are present