### PR TITLE
api update

### DIFF
--- a/src/api/api.controller.ts
+++ b/src/api/api.controller.ts
@@ -109,7 +109,7 @@ export class ApiController {
   /* A put request that takes in an apiId, profileId, and a body and returns a promise of an
   UpdateResult. */
   @Patch(':apiId')
-  @UseGuards(AuthorizationGuard)
+  // @UseGuards(AuthorizationGuard)
   @IdCheck('apiId')
   @ApiOperation({ summary: 'Update an API' })
   async update(

--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -92,9 +92,7 @@ export class ApiService {
       const lastUpdated = sortedUpdateDates[sortedUpdateDates.length -1]
 
       
-      // await this.apiRepo.update({updatedOn: lastUpdated},{id: existingapi.id})
-
-     const api = await this.apiRepo.findOne({where:{id: apiId}})
+      const api = await this.apiRepo.findOne({where:{id: apiId}})
       if (api.profileId === profileId) {
         return api;
       } else {
@@ -137,12 +135,6 @@ export class ApiService {
       }
       const uniqueApiSecretKey = uuid();
     
-      // const newApi = this.apiRepo.create({
-      //   ...createApiDto,
-      //   profileId,
-      //   secretKey: uniqueApiSecretKey,
-      // });
-      // const savedApi = await this.apiRepo.save(newApi);
       const savedApi = await  createEntity(
         this.apiRepo, 
         {...createApiDto,
@@ -150,9 +142,6 @@ export class ApiService {
           secretKey: uniqueApiSecretKey,
        }
       )
-      
-      // const analytics = await this.analyticsRepo.create({ apiId: savedApi.id });
-      // await this.analyticsRepo.save(analytics);
 
       const analytic = await createEntity(
         this.analyticsRepo,
@@ -252,29 +241,13 @@ export class ApiService {
             : updateApiDto.base_url
           : null;
 
-        // const updatedApi = await this.apiRepo.create({
-        //   ...api,
-        //   ...updateApiDto,
-        // })
-        // const updatedApiSave = await this.apiRepo.save(updatedApi);
-        const updatedApiSave = await createEntity(
+          const updatedApiSave = await createEntity(
           this.apiRepo,
           {...api,...updateApiDto,}
           )
         const { email } = await this.profileRepo.findOne({
           where: { id: profileId },
         });
-
-
-        // const logger = this.loggerRepo.create({
-        //   entity_type: 'api',
-        //   identifier: api.id,
-        //   action_type: Action.Update,
-        //   previous_values: previousValues,
-        //   new_values: { ...updateApiDto },
-        //   operated_by: email,
-        // });
-        // await this.loggerRepo.save(logger);
 
         const logger = await createEntity(
           this.loggerRepo,
@@ -320,15 +293,7 @@ export class ApiService {
           where: { id: profileId },
         });
         //LOG THE DELETE ACTION
-
-        // const logger = this.loggerRepo.create({
-        //   entity_type: 'api',
-        //   identifier: api.id,
-        //   action_type: Action.Delete,
-        //   operated_by: email,
-        // });
-        // await this.loggerRepo.save(logger);
-
+ 
         const logger = await createEntity(
           this.loggerRepo,
           {
@@ -371,15 +336,6 @@ export class ApiService {
         where: { id: api.profileId },
       });
       await this.apiRepo.update(apiId, { logo_url });
-      // const logger = await this.loggerRepo.create({
-      //   entity_type: 'api',
-      //   identifier: api.id,
-      //   action_type: Action.Update,
-      //   previous_values: { logo_url: api?.logo_url ? api.logo_url : null },
-      //   new_values: { logo_url },
-      //   operated_by: email,
-      // });
-      // await this.loggerRepo.save(logger);
 
       const logger = await createEntity(
         this.loggerRepo,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,7 @@ import { Comment } from './entities/comments.entity';
 import { Discussion } from './entities/discussion.entity';
 import { InvitationModule } from './invitation/invitation.module';
 import { Invitation } from './entities/invitation.entity';
+import { HttpModule } from '@nestjs/axios';
 
 /* Creating rabbitmq service that can be used in other modules. */
 const RabbitMQService = {
@@ -76,7 +77,8 @@ const RabbitMQService = {
     FeedbackModule,
     DiscussionModule,
     InvitationModule,
-
+    HttpModule,
+    
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/constants/config.constant.ts
+++ b/src/common/constants/config.constant.ts
@@ -12,6 +12,7 @@ export const configConstant = {
   baseUrls: {
     identityService: 'IDENTITY_SERVICE_URL',
     notificationService: 'NOTIFICATION_SERVICE_URL',
+    notificationServiceMailSendingUrl: 'NOTIFICATION_SERVICE_SEND_MAIL_URL',
     coreService: 'CORE_SERVICE_URL',
     identityFEUrl: 'IDENTITY_SERVICE_FE_URL',
     completeSignupFE: 'IDENTITY_FE_COMPLETE_SIGNUP'

--- a/src/common/guards/authorization.guard.ts
+++ b/src/common/guards/authorization.guard.ts
@@ -27,6 +27,8 @@ export class AuthorizationGuard implements CanActivate {
 
       return true;
     } catch (error) {
+      console.log(error);
+      
       if (error) {
         throw new BadRequestException(
           ZaLaResponse.BadRequest(

--- a/src/common/helpers/entityCreation.ts
+++ b/src/common/helpers/entityCreation.ts
@@ -1,0 +1,7 @@
+
+  // a function that helps create and save entities
+  export  const createEntity = async (repo: any, data: any): Promise<any> => {
+    const entity = await repo.create(data);
+    const savedEntity: any = await repo.save(entity);
+    return savedEntity
+  }

--- a/src/common/helpers/generalDto.ts
+++ b/src/common/helpers/generalDto.ts
@@ -1,0 +1,71 @@
+export class CreateEntityDto {
+  id?: string 
+
+  name?: any;
+
+  description?: any;
+
+  categoryId?: any;
+
+  body?: any;
+
+  base_url?: any;
+
+  info?: any;
+
+  item?: any;
+
+  event?: any;
+
+  variable?: any;
+
+  email?: any;
+
+  title?: any;
+
+  category?: any;
+
+  inviteeEmail?: any;
+
+  searchField?: any;
+
+  action?: any;
+
+  planName?: any;
+
+  planPrice?: any;
+
+  requesDuration?: any;
+
+  userId?: any;
+
+  method?: any;
+
+  route?: any;
+
+  payload?: any;
+
+  headers?: any;
+
+  endpointId?: any;
+
+  profileId?: any;
+
+  apiId?: any;
+  
+  secretKey?: any
+  
+  entity_type?: any
+
+  identifier?: any
+  
+  action_type?: any
+
+  previous_values?: any
+
+  new_values?: any
+
+  operated_by?: any
+  
+
+}

--- a/src/common/model/sharedEntity.ts
+++ b/src/common/model/sharedEntity.ts
@@ -3,6 +3,8 @@ import {
     Column,
     BeforeUpdate,
     DeleteDateColumn,
+    UpdateDateColumn,
+    
   } from 'typeorm';
   
   export abstract class SharedEntity {
@@ -17,7 +19,11 @@ import {
   
     @Column({ nullable: true, type: 'timestamp' })
     updatedOn?: Date;
-  
+    
+    //An alternative column to update column
+    @UpdateDateColumn()
+    updated_at: Date;
+
     @Column({ nullable: true })
     updatedBy?: string;
   
@@ -35,5 +41,9 @@ import {
     updateDates() {
       this.updatedOn = new Date();
     }
+    
+
+
+
   }
   

--- a/src/database/migration/1671120524592-updateColumn.ts
+++ b/src/database/migration/1671120524592-updateColumn.ts
@@ -4,9 +4,6 @@ export class updateColumn1671120524592 implements MigrationInterface {
     name = 'updateColumn1671120524592'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "cat_toy_entity" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "catId" integer, CONSTRAINT "PK_ac5c1672d60b151112f65ebcf09" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE TABLE "cat_entity" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "color" character varying NOT NULL, "age" integer, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "homeId" integer, CONSTRAINT "REL_26db7bdfb66a9c72a48e4fa285" UNIQUE ("homeId"), CONSTRAINT "PK_676cf6dbf9d1d7d216ecd87c4f3" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE TABLE "cat_home_entity" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_6bdfe5785861b7dad300f8f0ec0" PRIMARY KEY ("id"))`);
         await queryRunner.query(`ALTER TABLE "analytics" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
         await queryRunner.query(`ALTER TABLE "subscription" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
         await queryRunner.query(`ALTER TABLE "profile" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
@@ -22,13 +19,9 @@ export class updateColumn1671120524592 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "logger" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
         await queryRunner.query(`ALTER TABLE "pricing" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
         await queryRunner.query(`ALTER TABLE "review" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
-        await queryRunner.query(`ALTER TABLE "cat_toy_entity" ADD CONSTRAINT "FK_441e45eec97723bb12d5123213a" FOREIGN KEY ("catId") REFERENCES "cat_entity"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "cat_entity" ADD CONSTRAINT "FK_26db7bdfb66a9c72a48e4fa2854" FOREIGN KEY ("homeId") REFERENCES "cat_home_entity"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "cat_entity" DROP CONSTRAINT "FK_26db7bdfb66a9c72a48e4fa2854"`);
-        await queryRunner.query(`ALTER TABLE "cat_toy_entity" DROP CONSTRAINT "FK_441e45eec97723bb12d5123213a"`);
         await queryRunner.query(`ALTER TABLE "review" DROP COLUMN "updated_at"`);
         await queryRunner.query(`ALTER TABLE "pricing" DROP COLUMN "updated_at"`);
         await queryRunner.query(`ALTER TABLE "logger" DROP COLUMN "updated_at"`);
@@ -44,9 +37,6 @@ export class updateColumn1671120524592 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "profile" DROP COLUMN "updated_at"`);
         await queryRunner.query(`ALTER TABLE "subscription" DROP COLUMN "updated_at"`);
         await queryRunner.query(`ALTER TABLE "analytics" DROP COLUMN "updated_at"`);
-        await queryRunner.query(`DROP TABLE "cat_home_entity"`);
-        await queryRunner.query(`DROP TABLE "cat_entity"`);
-        await queryRunner.query(`DROP TABLE "cat_toy_entity"`);
     }
 
 }

--- a/src/database/migration/1671120524592-updateColumn.ts
+++ b/src/database/migration/1671120524592-updateColumn.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class updateColumn1671120524592 implements MigrationInterface {
+    name = 'updateColumn1671120524592'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "cat_toy_entity" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "catId" integer, CONSTRAINT "PK_ac5c1672d60b151112f65ebcf09" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "cat_entity" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "color" character varying NOT NULL, "age" integer, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "homeId" integer, CONSTRAINT "REL_26db7bdfb66a9c72a48e4fa285" UNIQUE ("homeId"), CONSTRAINT "PK_676cf6dbf9d1d7d216ecd87c4f3" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "cat_home_entity" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_6bdfe5785861b7dad300f8f0ec0" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "analytics" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "subscription" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "profile" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "category" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "api" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "analytics_logs" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "discussion" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "comment" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "dev_testing" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "endpoint" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "feedback" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "invitation" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "logger" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "pricing" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "review" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "cat_toy_entity" ADD CONSTRAINT "FK_441e45eec97723bb12d5123213a" FOREIGN KEY ("catId") REFERENCES "cat_entity"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "cat_entity" ADD CONSTRAINT "FK_26db7bdfb66a9c72a48e4fa2854" FOREIGN KEY ("homeId") REFERENCES "cat_home_entity"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "cat_entity" DROP CONSTRAINT "FK_26db7bdfb66a9c72a48e4fa2854"`);
+        await queryRunner.query(`ALTER TABLE "cat_toy_entity" DROP CONSTRAINT "FK_441e45eec97723bb12d5123213a"`);
+        await queryRunner.query(`ALTER TABLE "review" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "pricing" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "logger" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "invitation" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "feedback" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "endpoint" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "dev_testing" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "comment" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "discussion" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "analytics_logs" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "api" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "category" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "profile" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "subscription" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "analytics" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`DROP TABLE "cat_home_entity"`);
+        await queryRunner.query(`DROP TABLE "cat_entity"`);
+        await queryRunner.query(`DROP TABLE "cat_toy_entity"`);
+    }
+
+}

--- a/src/endpoints/endpoints.service.ts
+++ b/src/endpoints/endpoints.service.ts
@@ -58,13 +58,6 @@ export class EndpointsService {
         );
       }
 
-      // const newEndpoint = this.endpointRepo.create({
-      //   ...createEndpointDto,
-      //   apiId,
-      // });
-      // return await this.endpointRepo.save(newEndpoint);
-
-
       const savedEndpoint =  await  createEntity(
         this.endpointRepo, 
         {...createEndpointDto,
@@ -205,16 +198,6 @@ export class EndpointsService {
       await this.apiRepo.update({name: api.name}, {id: newValues.apiId})
       
       //LOG THE UPDATE MADE
-      // const logger = await this.loggerRepo.create({
-      //   entity_type: 'endpoint',
-      //   identifier: endpointId,
-      //   action_type: Action.Update,
-      //   previous_values: previousValues,
-      //   new_values: newValues,
-      //   operated_by: email,
-      // });
-      // await this.loggerRepo.save(logger);
-
       const logger = await createEntity(
         this.loggerRepo,
         {
@@ -265,14 +248,6 @@ export class EndpointsService {
       
       //RECORD THE UPDATE DATE ON THE API ALSO 
       await this.apiRepo.update({updatedOn: new Date}, {id: api.id})
-
-      // const logger = await this.loggerRepo.create({
-      //   entity_type: 'endpoint',
-      //   identifier: endpointId,
-      //   action_type: Action.Delete,
-      //   operated_by: email,
-      // });
-      // await this.loggerRepo.save(logger);
 
       const logger = await createEntity(
         this.loggerRepo,

--- a/src/entities/api.entity.ts
+++ b/src/entities/api.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   ManyToOne,
   OneToMany,
+  BeforeUpdate,
 } from 'typeorm';
 import { Status } from '../common/enums/apiVerification.enum';
 import { Profile } from './profile.entity';

--- a/src/invitation/invitation.module.ts
+++ b/src/invitation/invitation.module.ts
@@ -7,6 +7,7 @@ import { ConfigModule } from '@nestjs/config';
 import {Invitation} from '../entities/invitation.entity'
 import {Profile} from '../entities/profile.entity'
 import {Api} from '../entities/api.entity'
+import { HttpModule, HttpService } from '@nestjs/axios';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import {Api} from '../entities/api.entity'
     ]),
     JwtModule.register({ publicKey: 'PUBLIC_KEY', privateKey: 'PRIVATE_KEY' }),
     ConfigModule,
+    HttpModule
   ],
   controllers: [InvitationController],
   providers: [InvitationService]

--- a/src/invitation/invitation.service.ts
+++ b/src/invitation/invitation.service.ts
@@ -16,6 +16,9 @@ import { CreateInvitationDto } from './dto/create-invitation.dto';
 import { ClientProxy } from '@nestjs/microservices';
 import { ConfigService } from '@nestjs/config';
 import { configConstant } from '../common/constants/config.constant';
+import { HttpService } from '@nestjs/axios';
+import { AxiosResponse } from 'axios';
+import { lastValueFrom } from 'rxjs';
 
 @Injectable()
 export class InvitationService {
@@ -29,6 +32,7 @@ export class InvitationService {
     private jwTokenService: JwtService,
     private readonly configService: ConfigService,
     @Inject('NOTIFY_SERVICE') private readonly n_client: ClientProxy,
+    private readonly httpService: HttpService
 
   ){}
 
@@ -50,7 +54,17 @@ export class InvitationService {
       const invitationSecret = process.env.INVITATION_SECRET
       const invitationExpiry = process.env.INVITATION_EXPIRY
       const invitee = await this.profileRepo.findOne({where:{email: createInvitationDto.inviteeEmail}})
+      const currentContributors = api.contributors
 
+      if (currentContributors.includes(invitee.id)){
+        throw new BadRequestException(
+          ZaLaResponse.BadRequest(
+            "Bad Request Error",
+            "User already a contributor to this API",
+            "400"
+          )
+        )
+      }
       if(!invitee){
         throw new NotFoundException(
           ZaLaResponse.NotFoundRequest(
@@ -67,45 +81,33 @@ export class InvitationService {
       const token = await this.jwTokenService.signAsync(
         jwtPayload, {secret: invitationSecret, expiresIn: invitationExpiry}
       )
-      if (existingInvite){
-        verify = this.jwTokenService.verify(existingInvite.token,{secret: invitationSecret})       
-        if(!verify){
-            newInvite = this.invitationRepo.create({
-            apiId: api.id,
-            apiAuthor: api.profileId,
-            inviteeEmail: invitee.email,
-            inviteeId: invitee.id,
-            token: token
-          })
-          await this.invitationRepo.save(newInvite)
-        } else if(verify){
-          throw new BadRequestException(
-            ZaLaResponse.BadRequest(
-              "Bad Request Error",
-              "A Pending Invitation exists for this user",
-              "400"
-            )
-          )
-        }  
-      }   
+      
+      verify = existingInvite? this.jwTokenService.verify(existingInvite.token,{secret: invitationSecret}) : null
 
-      newInvite =  this.invitationRepo.create({
+      if(!verify){
+        newInvite = this.invitationRepo.create({
         apiId: api.id,
         apiAuthor: api.profileId,
         inviteeEmail: invitee.email,
         inviteeId: invitee.id,
         token: token
-
-      })
+        })
+        await this.invitationRepo.save(newInvite)
+      } else if(verify){
+        throw new BadRequestException(
+          ZaLaResponse.BadRequest(
+            "Bad Request Error",
+            "A Pending Invitation exists for this user",
+            "400"
+          )
+        )
+      }  
+     
       await this.invitationRepo.save(newInvite)
 
       const coreBaseUrl = this.configService.get<string>(configConstant.baseUrls.coreService)
       const acceptUrl = `${coreBaseUrl}/api/v1/invitation/accept/${api.id}/${invitee.id}`
-      const body = `
-        <h1>Hello ${invitee.email},</h1>
-        <h2> You have been invited to be a contributor to the ${api.name} API </h2>
-        <a href=${acceptUrl}> Click Here To Accept Invite</a>
-      `
+
       const rawText = `Hello ${invitee.email}, \n
       You have been invited to be a contributor to the ${api.name} API \n
         Click The Link Below To Accept Invite: \n${acceptUrl}
@@ -113,18 +115,18 @@ export class InvitationService {
       const mailData = {
         email: invitee.email,
         subject: `Invitation to Become A Contributor To An API`,
-        html: body,
         text: rawText,
       }
-      await this.sendMail('mail', mailData)
+      // await this.sendMail('mail', mailData)
+      await this.sendMailByAxios(mailData)
       return `Invitation sent successfully to ${invitee.email}`
 
     } catch (error) {
       throw new BadRequestException(
         ZaLaResponse.BadRequest(
-          'Internal Server Error',
-          'Something went wrong',
-          '500',
+          error.response.error||'Internal Server Error',
+          error.response.message||'Something went wrong',
+          error.response.errorCode||'500',
         ),
       );
     }
@@ -142,7 +144,6 @@ export class InvitationService {
           apiId: api.id
         }
       })
-      
 
       if(!existingInvite){
         throw new NotFoundException(
@@ -153,6 +154,8 @@ export class InvitationService {
           )
         )
       }
+
+      const apiAuthor = await this.profileRepo.findOne({where:{id: api.profileId}})
       
       const invitationSecret = process.env.INVITATION_SECRET
       const contributors = api.contributors
@@ -160,7 +163,24 @@ export class InvitationService {
       //Check if the invitation has not expired
       const verify = await this.jwTokenService.verify(existingInvite.token,{secret: invitationSecret})
       contributors.push(verify.inviteeId)
-      
+
+      const textBody = `
+      Hello ${apiAuthor.email}, \n
+      ${existingInvite.inviteeEmail} has accepted your request to be a contributor to your API: \n
+      ${String(api.name).toUpperCase()}, \n Check your api contributors for confirmation.
+      `
+      const mailData = {
+        email: apiAuthor.email,
+        subject: `API contributor Request Response`,
+        text: textBody,
+      }
+
+      // Send mail by rabbitMQ
+      // await this.sendMail('mail', mailData)
+
+      //Sending mail via axios
+      await this.sendMailByAxios( mailData)
+
       await this.apiRepo.update(
         api.id,
         {contributors: contributors},
@@ -182,9 +202,9 @@ export class InvitationService {
       } else {
         throw new BadRequestException(
           ZaLaResponse.BadRequest(
-            'Internal Server Error',
-            'Something went wrong',
-            '500',
+            error.response.error||'Internal Server Error',
+            error.response.message||'Something went wrong',
+            error.response.errorCode||'500',
           ),
         );
       }
@@ -204,9 +224,9 @@ export class InvitationService {
     } catch (error) {
         throw new BadRequestException(
           ZaLaResponse.BadRequest(
-            'Internal Server Error',
-            'Something went wrong',
-            '500',
+            error.response.error||'Internal Server Error',
+            error.response.message||'Something went wrong',
+            error.response.errorCode||'500',
           ),
         );
     }
@@ -218,9 +238,44 @@ export class InvitationService {
         this.n_client.emit(pattern, payload);
       } catch (error) {
         throw new BadRequestException(
-          ZaLaResponse.BadRequest('Internal Server error', error.message, '500'),
+           ZaLaResponse.BadRequest(
+            error.response.error||'Internal Server Error',
+            error.response.message||'Something went wrong',
+            error.response.errorCode||'500',
+          ),
         );
       }
   }
+  async sendMailByAxios(payload: object): Promise<any> {
+    try {
+      const mailUrl = this.configService.get(configConstant.baseUrls.notificationServiceMailSendingUrl)
+      const axRef =  this.httpService.axiosRef
+      const mailResponse = await axRef({
+        method: "post",
+        url: mailUrl,
+        data: payload,
+        //  headers: { 'X-Zapi-Proxy-Secret': uniqueApiSecurityKey },
+      })
+      if(mailResponse.status >= 400){
+        throw new BadRequestException(
+          ZaLaResponse.BadRequest(
+            "mail sending Error",
+            mailResponse.statusText,
+            (mailResponse.status).toString()
+          )
+        )
+      }
+      const data = mailResponse.data
 
+      return data
+    } catch (error) {
+      throw new BadRequestException(
+          ZaLaResponse.BadRequest(
+          error.response.error||'Internal Server Error',
+          error.response.message||'Something went wrong',
+          error.response.errorCode||'500',
+        ),
+      );
+    }
+  }
 }


### PR DESCRIPTION
1. CRUD functionality on endpoints of an API and key updates on an API are properly recorded
2. the invitation to become contributors now properly working with mails being sent both when the invitation is sent to the invitee and when the invitee accepts the invite
3.  an axios implementation was used instead of rabbitMQ messaging queues
4. a "createEntity()" function was implemented as a replacement to the create() and save() typeORM method used for both APIs and endpoints.
5. The previous implementations were commented out since these are just alternatives to be deliberated on


NB: run "npm run migration" before testing