### PR TITLE
filter out duplicates from the array and use the filtered array to create the endpoints. response should include both created and duplicate endpoints

### DIFF
--- a/src/endpoints/endpoints.controller.ts
+++ b/src/endpoints/endpoints.controller.ts
@@ -56,7 +56,12 @@ export class EndpointsController {
   async createMultipleEndpoints(
     @Param('apiId') apiId: string,
     @Body() createEndpointDtos: CreateEndpointDto[],
-  ): Promise<Ok<Endpoint[]>> {
+  ): Promise<
+    Ok<{
+      createdEndpoints: Endpoint[];
+      duplicateEndpoints: CreateEndpointDto[];
+    }>
+  > {
     const endpoints = await this.endpointsService.createMultipleEndpoints(
       apiId,
       createEndpointDtos,


### PR DESCRIPTION
**Description**

This pull request simplifies the implementation of createMultipleEndpoints in the NestJS codebase by refactoring the endpoint creation logic and reusing the existing createSingleEndpoint method. The changes aim to reduce code duplication and improve readability.

**Changes Made**

- Added a new createSingleEndpoint method that encapsulates the endpoint creation logic.
- Updated createMultipleEndpoints to call createSingleEndpoint for each endpoint in the createEndpointDtos array and handle duplicate endpoints using a try-catch block.
- Updated the try-catch block in createMultipleEndpoints to handle exceptions gracefully and ensure that the transaction is properly rolled back in case of errors.